### PR TITLE
Typo fix

### DIFF
--- a/custom_components/gaggimate/coordinator.py
+++ b/custom_components/gaggimate/coordinator.py
@@ -167,7 +167,7 @@ class GaggiMateCoordinator(DataUpdateCoordinator):
 
                 # DO NOT trigger reconnect from inside locked context
                 # just let caller handle it
-                raise UpdateFailed(f"Failed to connect: {err}") from errr
+                raise UpdateFailed(f"Failed to connect: {err}") from err
 
     async def _listen(self) -> None:
         """Listen for messages from the WebSocket."""


### PR DESCRIPTION
My HA logs were showing this:

> Logger: custom_components.gaggimate.coordinator
> Quelle: custom_components/gaggimate/coordinator.py:277
> 
> [...]
> 
> Reconnect failed: name 'errr' is not defined