### PR TITLE
Fix cooldown machine script entity name in dashboard YAML

### DIFF
--- a/examples/dashboard/gaggimate-dashboard.yaml
+++ b/examples/dashboard/gaggimate-dashboard.yaml
@@ -268,7 +268,7 @@ views:
               - show_name: true
                 show_icon: true
                 type: button
-                entity: script.gaggimate_cooldown
+                entity: script.gaggimate_cool_down_machine
                 name: Cooldown Machine
   - type: panel
     path: ''


### PR DESCRIPTION
After following the [dashboard setup guide](https://github.com/gaggimate/ha-integration/blob/main/examples/dashboard/README.md) and installing the scripts it mentions, the `Cooldown Machine` button had an error due to a mismatched entity name.

This updates it to match [the alias used in the script YAML](https://github.com/gaggimate/ha-integration/blob/main/README.md?plain=1#L235)