### PR TITLE
Fixed translation types

### DIFF
--- a/custom_components/gaggimate/translations/da.json
+++ b/custom_components/gaggimate/translations/da.json
@@ -27,12 +27,12 @@
         "max_shots": {
           "name": "Maksimalt antal skud at beholde",
           "description": "Behold dette antal nyeste skud; ældre skud fjernes.",
-          "example": 50
+          "example": "50"
         },
         "keep_annotated": {
           "name": "Bevar annoterede skud",
           "description": "Undtag annoterede skud fra trimning; max_shots gælder kun for ikke-annoterede skud.",
-          "example": false
+          "example": "false"
         }
       }
     }

--- a/custom_components/gaggimate/translations/en.json
+++ b/custom_components/gaggimate/translations/en.json
@@ -32,12 +32,12 @@
         "max_shots": {
           "name": "Maximum shots to keep",
           "description": "Keep this many newest shots; older shots will be removed.",
-          "example": 50
+          "example": "50"
         },
         "keep_annotated": {
           "name": "Preserve annotated shots",
           "description": "Exclude annotated shots from trimming; max_shots applies only to non-annotated shots.",
-          "example": false
+          "example": "false"
         }
       }
     }


### PR DESCRIPTION
Home Assistant expects translation values to be strings when validating integration translations.

The GaggiMate translations contained non-string example values:

"example": 50
"example": false

This caused the integration setup to fail with:

TypeError: expected str, got int
TypeError: expected str, got bool

when Home Assistant loaded the translations.

This change converts these values to strings so the integration can load correctly.