### PR TITLE
Merge partial evt:status frames instead of replacing coordinator data

### DIFF
--- a/custom_components/gaggimate/coordinator.py
+++ b/custom_components/gaggimate/coordinator.py
@@ -209,7 +209,10 @@ class GaggiMateCoordinator(DataUpdateCoordinator):
             if msg_type == MSG_TYPE_STATUS:
                 self._reconnect_attempt = 0
                 self._last_status_time = datetime.now()
-                self.async_set_updated_data(message)
+                # Firmware sends partial status frames: fast telemetry every tick and the
+                # slow-changing state only when it changes (plus a full snapshot on connect).
+                # Merge onto the last known status; a key sent as null clears it.
+                self.async_set_updated_data({**(self.data or {}), **message})
                 return
 
             if msg_type == "res:ota-settings":


### PR DESCRIPTION
## Problem

The next display firmware release splits `evt:status` into two kinds of frames on the same message type:

- **telemetry** every 500 ms: `ct`, `tt`, `pr`, `pt`, `fl`, `tf`, `pw`, `hp`, `bw`, `cw`, `pkr`, `pf`, `wl`, `tof`, `rssi`, `lat`, `process`
- **state** only when it changes (and in full right after connect, and at least every 10 s): `m`, `p`, `puid`, `cp`, `cd`, `gp`, `led`, `tw`, `bta`, `bt`, `btd`, `gtd`, `gtv`, `gt`, `gact`, `bc`, `sbat`, `up`, `warn`, `sys`

The coordinator currently does `self.async_set_updated_data(message)`, i.e. replaces its data with every frame. Against the new firmware that makes the mode select, mode sensor, profile sensor, scale sensors and target volume flip to unknown on every telemetry frame, and temperatures/pressure/flow/shot progress blank for a tick whenever a state frame arrives.

## Fix

Merge each frame onto the last known status:

```python
self.async_set_updated_data({**(self.data or {}), **message})
```

This is what the firmware's `docs/websocket-api.yaml` now specifies for all consumers: an absent key keeps its previous value, a key sent as `null` (e.g. `process`, `sbat`) clears it. Older firmware keeps sending full frames, which merge to the same result, so this is safe to release ahead of the firmware.

## Notes

- No entity or config-flow changes needed: the connection test only waits for any `evt:status`, and none of the request/response messages changed.
- New keys available for future entities: `sys` (`{s, m, c}`: display system state such as `starting`, `waiting`, `updating`, `error` plus the display's message and controller error code) and `warn` (per-warning `{k, l, a}`).